### PR TITLE
예약 시 메일 보내는 알림 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // mailSender
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/oishitable/OishiTableApplication.java
+++ b/src/main/java/com/sparta/oishitable/OishiTableApplication.java
@@ -3,9 +3,11 @@ package com.sparta.oishitable;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class OishiTableApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/sparta/oishitable/notification/entity/Notification.java
+++ b/src/main/java/com/sparta/oishitable/notification/entity/Notification.java
@@ -27,6 +27,9 @@ public class Notification extends BaseEntity {
     @Column(nullable = false)
     private String message;
 
+    private String email;
+
+    // 알림 보내야할 시간
     @Column(nullable = false)
     private LocalDateTime scheduledTime;
 
@@ -34,9 +37,10 @@ public class Notification extends BaseEntity {
     private boolean isSent;
 
     @Builder
-    public Notification(Long userId, String message, LocalDateTime scheduledTime) {
+    public Notification(Long userId, String message, String email, LocalDateTime scheduledTime) {
         this.userId = userId;
         this.message = message;
+        this.email = email;
         this.scheduledTime = scheduledTime;
     }
 

--- a/src/main/java/com/sparta/oishitable/notification/entity/Notification.java
+++ b/src/main/java/com/sparta/oishitable/notification/entity/Notification.java
@@ -1,0 +1,46 @@
+package com.sparta.oishitable.notification.entity;
+
+import com.sparta.oishitable.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "notifications")
+@NoArgsConstructor
+@DynamicInsert
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String message;
+
+    @Column(nullable = false)
+    private LocalDateTime scheduledTime;
+
+    @ColumnDefault(value = "false")
+    private boolean isSent;
+
+    @Builder
+    public Notification(Long userId, String message, LocalDateTime scheduledTime) {
+        this.userId = userId;
+        this.message = message;
+        this.scheduledTime = scheduledTime;
+    }
+
+    public void updateSent() {
+        this.isSent = true;
+    }
+}

--- a/src/main/java/com/sparta/oishitable/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sparta/oishitable/notification/repository/NotificationRepository.java
@@ -11,6 +11,7 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
 
+    // 알림 미전송 된 것 중 보내야 하는 알림 조회
     @Query("SELECT n FROM Notification n WHERE n.isSent = false AND n.scheduledTime <= :currentTime")
     List<Notification> findDueNotifications(@Param("currentTime") LocalDateTime currentTime);
 }

--- a/src/main/java/com/sparta/oishitable/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sparta/oishitable/notification/repository/NotificationRepository.java
@@ -1,0 +1,16 @@
+package com.sparta.oishitable.notification.repository;
+
+import com.sparta.oishitable.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+
+    @Query("SELECT n FROM Notification n WHERE n.isSent = false AND n.scheduledTime <= :currentTime")
+    List<Notification> findDueNotifications(@Param("currentTime") LocalDateTime currentTime);
+}

--- a/src/main/java/com/sparta/oishitable/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/sparta/oishitable/notification/scheduler/NotificationScheduler.java
@@ -1,0 +1,29 @@
+package com.sparta.oishitable.notification.scheduler;
+
+import com.sparta.oishitable.domain.customer.reservation.entity.Reservation;
+import com.sparta.oishitable.notification.entity.Notification;
+import com.sparta.oishitable.notification.repository.NotificationRepository;
+import com.sparta.oishitable.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationService notificationService;
+
+    @Scheduled(cron = "0 */5 * * * ?")
+    public void processDueNotifications() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Notification> dueNotifications = notificationRepository.findDueNotifications(now);
+        for (Notification notification : dueNotifications) {
+            notificationService.sendEmail(notification);
+        }
+    }
+}

--- a/src/main/java/com/sparta/oishitable/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/sparta/oishitable/notification/scheduler/NotificationScheduler.java
@@ -18,6 +18,7 @@ public class NotificationScheduler {
     private final NotificationRepository notificationRepository;
     private final NotificationService notificationService;
 
+    // 5분마다 현재 시간이 전송해야하는 시간을 지난 것들 메일 보내기
     @Scheduled(cron = "0 */5 * * * ?")
     public void processDueNotifications() {
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/sparta/oishitable/notification/service/NotificationService.java
+++ b/src/main/java/com/sparta/oishitable/notification/service/NotificationService.java
@@ -19,13 +19,15 @@ public class NotificationService {
 
         SimpleMailMessage message = new SimpleMailMessage();
 
+        // 메일 발신자, 수신자, 제목 , 내용 설정
         message.setFrom(SENDER);
-        message.setTo("gkdl4239@gmail.com"); // 실제 환경에서는 사용자 이메일 주소로 대체
+        message.setTo(notification.getEmail());
         message.setSubject("오이시 테이블 예약 알림");
         message.setText(notification.getMessage());
         mailSender.send(message);
 
         notification.updateSent();
+        // 영속성 컨텍스트에 관리 안되므로 save 로 변경사항 저장
         notificationRepository.save(notification);
     }
 }

--- a/src/main/java/com/sparta/oishitable/notification/service/NotificationService.java
+++ b/src/main/java/com/sparta/oishitable/notification/service/NotificationService.java
@@ -1,0 +1,31 @@
+package com.sparta.oishitable.notification.service;
+
+import com.sparta.oishitable.notification.entity.Notification;
+import com.sparta.oishitable.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final JavaMailSender mailSender;
+    private final NotificationRepository notificationRepository;
+    private final String SENDER = "oishitable52@gmail.com";
+
+    public void sendEmail(Notification notification) {
+
+        SimpleMailMessage message = new SimpleMailMessage();
+
+        message.setFrom(SENDER);
+        message.setTo("gkdl4239@gmail.com"); // 실제 환경에서는 사용자 이메일 주소로 대체
+        message.setSubject("오이시 테이블 예약 알림");
+        message.setText(notification.getMessage());
+        mailSender.send(message);
+
+        notification.updateSent();
+        notificationRepository.save(notification);
+    }
+}


### PR DESCRIPTION
## #️⃣ Kan Board Number

#74

## 📝 요약

예약 생성 시에 알림 객체를 만들고 DB에 저장하여 스케줄러로 5분마다 돌면서 전송 시각에 맞춰 보내는 기능

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문

일단 지금은 예약 서비스단에서 알림을 직접 만들어 저장하는 구조라 의존하는 형태라서 Spring Event나 메세지 큐 같은 미들웨어를 도입해서 의존성을 떨어뜨리게끔 해야할듯

초기버전이라고 생각해주시면 됨다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)