### PR TITLE
Redis / RabbitMQ 컨테이너 삭제

### DIFF
--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -3,21 +3,20 @@ services:
     image: ${DOCKER_HUB_USERNAME}/oishitable:latest
     container_name: oishitable-app
     restart: always
-    depends_on:
-      - redis
-      - rabbitmq
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://${RDS_ENDPOINT}:3306/oishitable
       SPRING_DATASOURCE_USERNAME: ${RDS_USERNAME}
       SPRING_DATASOURCE_PASSWORD: ${RDS_PASSWORD}
       SPRING_JPA_HIBERNATE_DDL_AUTO: update
-      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_HOST: ${REDIS_HOST}
       SPRING_DATA_REDIS_PORT: 6379
       SPRING_DATA_REDIS_URL: redis://redis:6379
-      SPRING_RABBITMQ_HOST: rabbitmq
-      SPRING_RABBITMQ_PORT: 5672
-      SPRING_RABBITMQ_USERNAME: guest
-      SPRING_RABBITMQ_PASSWORD: guest
+      SPRING_RABBITMQ_HOST: ${RABBITMQ_HOST}
+      SPRING_RABBITMQ_PORT: 5671
+      SPRING_RABBITMQ_USERNAME: ${RABBITMQ_USERNAME}
+      SPRING_RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD}
+      SPRING_RABBITMQ_VIRTUAL_HOST: /
+      SPRING_RABBITMQ_SSL_ENABLED: true
       SPRING_JWT_SECRET_ACCESS: ${JWT_SECRET_ACCESS}
       SPRING_JWT_SECRET_REFRESH: ${JWT_SECRET_REFRESH}
       SPRING_MAIL_HOST: smtp.gmail.com
@@ -36,24 +35,6 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-
-  redis:
-    image: redis:latest
-    container_name: redis-container
-    ports:
-      - "6379:6379"
-    restart: always
-
-  rabbitmq:
-    image: rabbitmq:management
-    container_name: rabbitmq-container
-    ports:
-      - "5672:5672"
-      - "15672:15672"
-    environment:
-      RABBITMQ_DEFAULT_USER: guest
-      RABBITMQ_DEFAULT_PASS: guest
-    restart: always
 
 volumes:
   mysql-data:


### PR DESCRIPTION
## #️⃣ Kan Board Number

#164

## 📝 요약

cd를 통해 Redis와 RabbitMQ를 각각의 인스턴스 로컬에 컨테이너로 띄우는게 아니라
AWS의 관리형 서비스를 이용하여 외부의 클러스터로 전환해 모든 인스턴스가 같은 곳을 바라보게끔 대체하였습니다

Redis -> ElastiCache
RabbitMQ -> Amazon MQ for RabbitMQ

## 🛠️ PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문

ElasticSearch 도 클러스터로 구축할 예정입니다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [ ] 커밋 메시지 컨벤션 준수
- [ ] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)