### PR TITLE
엘라스틱 서치 수정

### DIFF
--- a/src/main/java/com/sparta/oishitable/domain/customer/post/controller/PostController.java
+++ b/src/main/java/com/sparta/oishitable/domain/customer/post/controller/PostController.java
@@ -80,14 +80,12 @@ public class PostController {
 
     @GetMapping("/keyword/elastic")
     public ResponseEntity<Slice<PostKeywordResponse>> findPostsByKeywordWithElastic(
-            @RequestParam(required = false) Long userId,
             @RequestParam(required = false) Long regionId,
             @RequestParam(required = false) Long cursorValue,
             @RequestParam String keyword,
             @RequestParam(defaultValue = "10") int limit
     ) {
         Slice<PostKeywordResponse> response = postElasticService.findPostsByKeywordWithElastic(
-                userId,
                 regionId,
                 cursorValue,
                 keyword,

--- a/src/main/java/com/sparta/oishitable/domain/customer/post/entity/PostDocument.java
+++ b/src/main/java/com/sparta/oishitable/domain/customer/post/entity/PostDocument.java
@@ -18,6 +18,9 @@ public class PostDocument {
     @Id
     private String id;
 
+    @Field(name = "post_id", type = FieldType.Long)
+    private Long postId;
+
     @Field(name = "user_id", type = FieldType.Long)
     private Long userId;
 
@@ -44,6 +47,7 @@ public class PostDocument {
         String id = String.valueOf(post.getId());
         return new PostDocument(
                 id,
+                post.getId(),
                 user.getId(),
                 region.getId(),
                 post.getTitle(),

--- a/src/main/java/com/sparta/oishitable/domain/customer/post/service/PostElasticService.java
+++ b/src/main/java/com/sparta/oishitable/domain/customer/post/service/PostElasticService.java
@@ -3,7 +3,6 @@ package com.sparta.oishitable.domain.customer.post.service;
 import com.sparta.oishitable.domain.customer.post.dto.response.PostKeywordResponse;
 import com.sparta.oishitable.domain.customer.post.entity.Post;
 import com.sparta.oishitable.domain.customer.post.entity.PostDocument;
-import com.sparta.oishitable.domain.customer.post.repository.PostElasticRepository;
 import com.sparta.oishitable.domain.customer.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -19,8 +18,6 @@ import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Service;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -30,12 +27,10 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class PostElasticService {
 
-    private final PostElasticRepository postElasticRepository;
     private final ElasticsearchOperations elasticsearchOperations;
     private final PostRepository postRepository;
 
     public Slice<PostKeywordResponse> findPostsByKeywordWithElastic(
-            Long userId,
             Long regionId,
             Long cursorValue,
             String keyword,
@@ -62,12 +57,9 @@ public class PostElasticService {
 
         PageRequest pageRequest = PageRequest.of(0, limit + 1, Sort.by(Sort.Direction.DESC, "post_id"));
 
-        // boolQuery.toString()으로 생성된 JSON 문자열을 Base64로 인코딩
-        String base64EncodedQuery = Base64.getEncoder().encodeToString(boolQuery.toString().getBytes(StandardCharsets.UTF_8));
-
         // NativeQueryBuilder를 사용하여 쿼리 생성 (최신 API)
         NativeQuery query = new NativeQueryBuilder()
-                .withQuery(q -> q.wrapper(w -> w.query(base64EncodedQuery)))
+                .withQuery(q -> q.wrapper(w -> w.query(boolQuery.toString())))
                 .withPageable(pageRequest)
                 .build();
 


### PR DESCRIPTION
## #️⃣ Kan Board Number

#127 

## 📝 요약

엘라스틱 조회 쿼리문에서 postId를 통해 커서조회를 하고있는데 문서에는 postId값이 포함되지 않아 생기는 버그 수정

## 🛠️ PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 논의사항 or 질문


## ✅ PR Checklist

PR이 다음 요구 사항을 충족했는지 확인하기!

- [ ] 커밋 메시지 컨벤션 준수
- [ ] 변경 사항 테스트 여부 체크(버그 수정/기능 테스트)